### PR TITLE
Bump rake and bundler to newer versions

### DIFF
--- a/rake-ant.gemspec
+++ b/rake-ant.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Now that rake 13.x and bundler 2.x are available
and being widely used, let's use those versions
instead.

Closes: #2

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>